### PR TITLE
feat: Add board meta data requesting and parsing

### DIFF
--- a/electron/Interpolation.js
+++ b/electron/Interpolation.js
@@ -10,9 +10,14 @@ class Interpolation {
     return value
   }
 
-  static interpolateCustomEvent(value){
+  static interpolateMetadata(value) {
+    console.debug('metadata value: ', value)
+    return value;
+  }
+
+  static interpolateCustomEvent(value) {
     let int = Math.round(value)
-    if(int === 0){
+    if (int === 0) {
       return value
     }
     return `value: ${value}`

--- a/electron/Packet.js
+++ b/electron/Packet.js
@@ -5,8 +5,8 @@ class Packet {
    * @param {Array} values
    * @param {number} timestamp
    */
-  constructor(id, values, timestamp=null) {
-    if(timestamp === null) {
+  constructor(id, values, timestamp = null) {
+    if (timestamp === null) {
       this.timestamp = Date.now();
     } else {
       this.timestamp = timestamp;
@@ -30,23 +30,25 @@ class Packet {
   /**
    * Parses stringified packet into object
    * @param {String} rawData
+   * @param parseAsString should the packet values not be converted to float?
    * @returns parsed packet
    */
-  static parsePacket(rawData) {
+  static parsePacket(rawData, parseAsString = false) {
     const timestamp = Date.now(); // TODO: Change this to come from packet
     let data = rawData.replace(/(\r\n|\n|\r)/gm, '');
     const start = data.indexOf('{');
     const end = data.indexOf('}');
-    if(start < 0 || end < 0) {
+    if (start < 0 || end < 0) {
       return null;
     }
     data = data.substring(start + 1, end);
-    const [ rawValues, checksum ] = data.replace(/({|})/gm, '').split('|');
+    const [rawValues, checksum] = data.replace(/({|})/gm, '').split('|');
     const calculatedChecksum = Packet.fletcher16(Buffer.from(rawValues, 'binary'));
-    if(Number('0x' + checksum) !== calculatedChecksum) {
+    if (Number('0x' + checksum) !== calculatedChecksum) {
       return null;
     }
-    const [ id, ...values ] = rawValues.split(',').map(v => parseFloat(v));
+
+    const [id, ...values] = rawValues.split(',').map(v => parseAsString ? v.toString().replace(/`/g, ",") : parseFloat(v));
     return new Packet(id, values, timestamp);
   }
 
@@ -60,8 +62,8 @@ class Packet {
   static fletcher16(data) {
     let a = 0, b = 0;
     for (let i = 0; i < data.length; i++) {
-        a = (a + data[i]) % 255;
-        b = (b + a) % 255;
+      a = (a + data[i]) % 255;
+      b = (b + a) % 255;
     }
     return a | (b << 8);
   }

--- a/electron/UdpPort.js
+++ b/electron/UdpPort.js
@@ -24,15 +24,25 @@ class UdpPort {
 
     this.server.on('message', (msg, rinfo) => {
       let b = this.boards[rinfo.address];
-      if (b === undefined && rinfo.address !== '127.0.0.1') { // enables testing packets from localhost
+      if (b === undefined && rinfo.address !== '127.0.0.1') {
+        // enables testing packets from localhost
         console.info(`received packet from unknown remote: ${rinfo.address}`)
         return;
       }
-      const pkt = Packet.parsePacket(msg.toString());
-      if (b === undefined && rinfo.address === '127.0.0.1'){ // if packet is from local test, set b to given address
-        b = this.boards[`10.0.0.${pkt.values[0]}`]
-        pkt.values.shift()
+      let pkt = Packet.parsePacket(msg.toString());
+      if (b === undefined && rinfo.address === '127.0.0.1') {
+        b = this.boards[`10.0.0.${pkt.values[0]}`] // if packet is from local test, set b to given address
       }
+      const _pkt = b.packets[pkt?.id]
+      if (_pkt && Object.keys(_pkt).map(_k => _pkt[_k]).reduce((acc, cur) => acc || cur.parseAsString, false)) {
+        // should be parsed as string
+        pkt = Packet.parsePacket(msg.toString(), true)
+      }
+
+      if (rinfo.address === '127.0.0.1') {
+        pkt.values.shift() // discard first value from local testing packet
+      }
+
       if (pkt) {
         const update = b.processPacket(pkt);
         if (update === undefined) return;

--- a/telemetry/src/components/MessageDisplaySquare.js
+++ b/telemetry/src/components/MessageDisplaySquare.js
@@ -478,6 +478,8 @@ class MessageDisplaySquare
       }
     }
 
+    const beforeLength = this.rawLogs.current?.length || 0
+
     if (this.rawLogs.current) {
       this.rawLogs.current
         .push(...Object.keys(update)
@@ -494,7 +496,10 @@ class MessageDisplaySquare
     } else {
       this.rawLogs.current = this.state.logs
     }
-    this.debouncedHandleUpdate()
+
+    if(beforeLength !== this.rawLogs.current.length){
+      this.debouncedHandleUpdate()
+    }
   }
 
   _handleUpdate() {
@@ -539,6 +544,7 @@ class MessageDisplaySquare
               pauseAutoScroll: false
             })
           } else {
+            console.debug('recalculating el heights because of scroll')
             this.recalculateElHeights()
           }
         }


### PR DESCRIPTION
* Sends packet 99 to each board when the board is connected (Board.js -> resetWatchdog)
* Adds parseAsString field in packet definitions to allow the field to not be parsed as float
* Adds an universal packet definition const in Board.js, so packet ID #99 can be defined across all boards
* Adds meta data interpolator that just returns the value as itself