### PR TITLE
New influx data recording scheme

### DIFF
--- a/electron/App.js
+++ b/electron/App.js
@@ -213,7 +213,7 @@ class App {
     console.debug('setting up ipc channels')
     this.addIPC('connect-influx', (e, host, port, protocol, username, password) => this.influxDB.connect(host, port, protocol, username, password), false);
     this.addIPC('get-databases', this.influxDB.getDatabaseNames);
-    this.addIPC('set-database', (e, database) => this.influxDB.setDatabase(database));
+    this.addIPC('set-database', (e, database, recording) => this.influxDB.setDatabase(database, recording));
     this.addIPC('set-darkmode', (e, isDark) => this.sendDarkModeUpdate(isDark), false);
     this.addIPC('set-procedure-state', (e, procState) => this.influxDB.setProcedureStep(procState));
 

--- a/telemetry/src/api/Comms.js
+++ b/telemetry/src/api/Comms.js
@@ -133,8 +133,8 @@ class Comms {
     return await this.ipc.invoke('get-databases');
   }
 
-  async setDatabase(database) {
-    return await this.ipc.invoke('set-database', database);
+  async setDatabase(database, recording) {
+    return await this.ipc.invoke('set-database', database, recording);
   }
 
   async setDarkMode(isDark) {

--- a/telemetry/src/components/Settings.js
+++ b/telemetry/src/components/Settings.js
@@ -38,14 +38,14 @@ class Settings extends Component {
       influxConnecting: false,
       influxDatabase: '',
       influxDatabaseList: [],
+      recordingName: "",
     };
 
     this.updateInfluxHost = this.updateInfluxHost.bind(this);
     this.updateInfluxPort = this.updateInfluxPort.bind(this);
     this.updateInfluxProtocol = this.updateInfluxProtocol.bind(this);
-    this.updateInfluxUsername = this.updateInfluxUsername.bind(this);
-    this.updateInfluxPassword = this.updateInfluxPassword.bind(this);
     this.updateInfluxDatabase = this.updateInfluxDatabase.bind(this);
+    this.updateRecordingName = this.updateRecordingName.bind(this);
 
     this.connectToInflux = this.connectToInflux.bind(this);
     this.setInfluxDatabase = this.setInfluxDatabase.bind(this);
@@ -54,9 +54,8 @@ class Settings extends Component {
   updateInfluxHost(e) { this.setState({ influxHost: e.target.value }); }
   updateInfluxPort(e) { this.setState({ influxPort: parseInt(e.target.value) }); }
   updateInfluxProtocol(e) { this.setState({ influxProtocol: e.target.value }); }
-  updateInfluxUsername(e) { this.setState({ influxUsername: e.target.value }); }
-  updateInfluxPassword(e) { this.setState({ influxPassword: e.target.value }); }
   updateInfluxDatabase(e) { this.setState({ influxDatabase: e.target.value }); }
+  updateRecordingName(e) { this.setState({ recordingName: e.target.value }); }
 
   async connectToInflux() {
     this.setState({ influxConnecting: true });
@@ -75,8 +74,8 @@ class Settings extends Component {
   }
 
   async setInfluxDatabase() {
-    const { influxDatabase } = this.state;
-    await Comms.setDatabase(influxDatabase);
+    const { influxDatabase, recordingName } = this.state;
+    await Comms.setDatabase(influxDatabase, recordingName);
     // Initialize Procedures. Done here since selecting databse is last step before data is recorded
     // TODO: Maybe move this somewhere else, or rename function
     await Comms.setProcedureState(0);
@@ -93,11 +92,10 @@ class Settings extends Component {
     const { influxHost,
             influxPort,
             influxProtocol,
-            influxUsername,
-            influxPassword,
             influxConnecting,
             influxDatabase,
-            influxDatabaseList } = this.state;
+            influxDatabaseList,
+            recordingName } = this.state;
     const influxConnected = influxDatabaseList.length > 0;
     return (
       <Dialog open={ open } onClose={ closeSettings }>
@@ -130,21 +128,6 @@ class Settings extends Component {
               </Select>
             </div>
             <div>
-              <TextField
-                label='influx username'
-                value={ influxUsername }
-                onChange={ this.updateInfluxUsername }
-                className={ classes.fields }
-              />
-              <TextField
-                label='influx password'
-                type='password'
-                value={ influxPassword }
-                onChange={ this.updateInfluxPassword }
-                className={ classes.fields }
-              />
-            </div>
-            <div>
               <Button onClick={ this.connectToInflux } color='primary' variant='contained' className={ influxConnected ? classes.connectedButton : classes.connectButton } disabled={ influxConnecting || influxConnected }>
                 { influxConnected ? 'Connected' : 'Connect to Influx' }
               </Button>
@@ -162,7 +145,13 @@ class Settings extends Component {
                   <MenuItem key={db} value={db}>{db}</MenuItem>
                 ))}
               </Select>
-              <Button onClick={ this.setInfluxDatabase } color='primary' variant='contained' disabled={ !influxConnected }>Select DB</Button>
+              <TextField
+                label='recording name'
+                value={ recordingName }
+                onChange={ this.updateRecordingName }
+                className={ classes.fields }
+              />
+              <Button onClick={ this.setInfluxDatabase } color='primary' variant='contained' disabled={ (!influxConnected || recordingName==="") }>Apply</Button>
             </div>
           </form>
         </DialogContent>


### PR DESCRIPTION
Instead of recording to a new database each day/worksession, we just record to the same database (e3_cart, had, e3_vertical, etc) but tag the data with a recording name. The recording name can still be the standard `2024_03_29_worksession` type format. This PR also fixes a bug with the influx data recording where we'd drop some data every second.